### PR TITLE
Breaking PutMetricData calls into chunks

### DIFF
--- a/lib/backend.js
+++ b/lib/backend.js
@@ -41,18 +41,19 @@ _.extend(Backend.prototype, {
       collect_counters(date, metrics.counters, this.dimensions),
       collect_gauges(date, metrics.gauges, this.dimensions))
 
-    if (data.length == 0)
-      return
+    while (data.length > 0) {
+      var params = {
+        Namespace: this.namespace,
+        MetricData: data.slice(0, 20)
+      }
 
-    var params = {
-      Namespace: this.namespace,
-      MetricData: data
+      var stats = this.stats
+      this.client.putMetricData(params, function (err, data) {
+        err ? report_error(err, stats) : report_success(params, stats)
+      })
+
+      data = data.slice(20);
     }
-
-    var stats = this.stats
-    this.client.putMetricData(params, function(err, data) {
-      err ? report_error(err, stats) : report_success(params, stats)
-    })
   },
 
   status: function(callback) {

--- a/test/backend.test.js
+++ b/test/backend.test.js
@@ -39,24 +39,24 @@ describe('flush with no metrics', function() {
   })
 })
 
-//describe('flush with too many metrics', function() {
-//  var metrics = []
-//  var cloudwatch = new Fake.CloudWatch()
-//  var backend = new Backend({
-//    client: cloudwatch, namespace: 'abc.123'
-//  })
-//
-//  beforeEach(function() {
-//    backend.flush(Fixture.timestamp, {
-//      counters: Fixture.manyCounters
-//    })
-//    metrics = cloudwatch.MetricData
-//  })
-//
-//  it('should break metrics into 2 calls to Cloudwatch', function() {
-//    expect(metrics).to.have.length(2)
-//  })
-//})
+describe('flush with too many metrics', function() {
+  var cloudwatch = new Fake.CloudWatch()
+  var backend = new Backend({
+    client: cloudwatch, namespace: 'abc.123'
+  })
+
+  beforeEach(function() {
+    backend.flush(Fixture.timestamp, {
+      counters: Fixture.manyCounters
+    })
+  })
+
+  it('should break metrics into 2 calls to Cloudwatch', function() {
+    expect(cloudwatch.params).to.have.length(2)
+    expect(cloudwatch.params[0]).to.have.length(20)
+    expect(cloudwatch.params[1]).to.have.length(20)
+  })
+})
 
 describe('flushing counters', function() {
   var metric = null

--- a/test/backend.test.js
+++ b/test/backend.test.js
@@ -35,9 +35,28 @@ describe('flush with no metrics', function() {
   })
 
   it('should not send counters', function() {
-    expect(cloudwatch.MetricData).to.have.length(0)
+    expect(cloudwatch.params).to.have.length(0)
   })
 })
+
+//describe('flush with too many metrics', function() {
+//  var metrics = []
+//  var cloudwatch = new Fake.CloudWatch()
+//  var backend = new Backend({
+//    client: cloudwatch, namespace: 'abc.123'
+//  })
+//
+//  beforeEach(function() {
+//    backend.flush(Fixture.timestamp, {
+//      counters: Fixture.manyCounters
+//    })
+//    metrics = cloudwatch.MetricData
+//  })
+//
+//  it('should break metrics into 2 calls to Cloudwatch', function() {
+//    expect(metrics).to.have.length(2)
+//  })
+//})
 
 describe('flushing counters', function() {
   var metric = null
@@ -50,11 +69,11 @@ describe('flushing counters', function() {
     backend.flush(Fixture.timestamp, {
       counters: Fixture.counters
     })
-    metric = _.first(cloudwatch.MetricData)
+    metric = _.first(_.first(cloudwatch.params).MetricData)
   })
 
   it('should send a namespace', function() {
-    expect(cloudwatch.Namespace).to.equal('abc.123')
+    expect(cloudwatch.params[0].Namespace).to.equal('abc.123')
   })
 
   it('should send a counter', function() {
@@ -82,14 +101,14 @@ describe('flushing counters', function() {
   })
 
   it('should not send a statsd counter', function() {
-    var counters = _.filter(cloudwatch.MetricData, function(c) {
+    var counters = _.filter(_.first(cloudwatch.params).MetricData, function(c) {
       return c.MetricName.indexOf('statsd.') == 0
     })
     expect(counters).to.have.length(0)
   })
 })
 
-describe('flusing timers', function() {
+describe('flushing timers', function() {
   var metric = null
   var cloudwatch = new Fake.CloudWatch()
   var backend = new Backend({
@@ -100,11 +119,11 @@ describe('flusing timers', function() {
     backend.flush(Fixture.timestamp, {
       timers: Fixture.timers
     })
-    metric = _.first(cloudwatch.MetricData)
+    metric = _.first(cloudwatch.params[0].MetricData)
   })
 
   it('should send a namespace', function() {
-    expect(cloudwatch.Namespace).to.equal('abc.123')
+    expect(cloudwatch.params[0].Namespace).to.equal('abc.123')
   })
 
   it('should send a timer', function() {
@@ -155,11 +174,11 @@ describe('flushing gauges', function() {
     backend.flush(Fixture.timestamp, {
       gauges: Fixture.gauges
     })
-    metric = _.first(cloudwatch.MetricData)
+    metric = _.first(cloudwatch.params[0].MetricData)
   })
 
   it('should send a namespace', function() {
-    expect(cloudwatch.Namespace).to.equal('abc.123')
+    expect(cloudwatch.params[0].Namespace).to.equal('abc.123')
   })
 
   it('should send a gauge', function() {

--- a/test/backend.test.js
+++ b/test/backend.test.js
@@ -53,8 +53,8 @@ describe('flush with too many metrics', function() {
 
   it('should break metrics into 2 calls to Cloudwatch', function() {
     expect(cloudwatch.params).to.have.length(2)
-    expect(cloudwatch.params[0]).to.have.length(20)
-    expect(cloudwatch.params[1]).to.have.length(20)
+    expect(cloudwatch.params[0].MetricData).to.have.length(20)
+    expect(cloudwatch.params[1].MetricData).to.have.length(1)
   })
 })
 

--- a/test/fake.js
+++ b/test/fake.js
@@ -2,14 +2,15 @@ var _ = require('underscore')
 
 var Fake = module.exports = {
   CloudWatch: function() {
-    this.Namespace = ''
-    this.MetricData = []
+    //this.Namespace = ''
+    //this.MetricData = []
+    this.params = []
   },
 }
 
 _.extend(Fake.CloudWatch.prototype, {
   putMetricData: function(params, complete) {
-    _.extend(this, params)
+    this.params.push(params);
     complete(null, {})
   }
 })

--- a/test/fixture.js
+++ b/test/fixture.js
@@ -14,5 +14,28 @@ module.exports = {
   gauges: {
     'api.num_sessions': 50,
     'statsd.timestamp_lag': 0
-  }
+  },
+  manyCounters: {
+    'counter00': 100,
+    'counter01': 100,
+    'counter02': 100,
+    'counter03': 100,
+    'counter04': 100,
+    'counter05': 100,
+    'counter06': 100,
+    'counter07': 100,
+    'counter08': 100,
+    'counter09': 100,
+    'counter10': 100,
+    'counter11': 100,
+    'counter12': 100,
+    'counter13': 100,
+    'counter14': 100,
+    'counter15': 100,
+    'counter16': 100,
+    'counter17': 100,
+    'counter18': 100,
+    'counter19': 100,
+    'counter20': 100
+  },
 }


### PR DESCRIPTION
This is required if you have more than 20 things to send. See http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/cloudwatch_limits.html